### PR TITLE
Add organization-only authentication with kill switch

### DIFF
--- a/docs/AUTHENTICATION_SETUP.md
+++ b/docs/AUTHENTICATION_SETUP.md
@@ -1,0 +1,280 @@
+# Authentication Setup Guide
+
+This guide explains how to configure Azure AD (Microsoft Entra ID) authentication to restrict app access to your organization only.
+
+## Overview
+
+The app uses Microsoft Azure AD for single sign-on (SSO). When enabled:
+- All pages require authentication
+- All API endpoints require authentication
+- Only users in your organization's Azure AD tenant can access the app
+
+A **kill switch** (`AUTH_REQUIRED` environment variable) allows you to disable authentication without code changes if something goes wrong.
+
+---
+
+## Prerequisites
+
+Before starting, you need:
+1. Access to your organization's Azure Portal (portal.azure.com)
+2. Permission to create App Registrations (or work with IT who can)
+3. Access to Vercel project settings
+
+---
+
+## Step 1: Azure AD App Registration
+
+### 1.1 Create the App Registration
+
+1. Go to [Azure Portal](https://portal.azure.com)
+2. Navigate to **Azure Active Directory** → **App registrations**
+3. Click **New registration**
+4. Configure:
+   - **Name:** `Document Processing Suite` (or your preferred name)
+   - **Supported account types:** Select **"Accounts in this organizational directory only"** (Single tenant)
+   - **Redirect URI:**
+     - Platform: **Web**
+     - URL: `https://your-app.vercel.app/api/auth/callback/azure-ad`
+     - (Replace with your actual Vercel domain)
+5. Click **Register**
+
+### 1.2 Note the Application Details
+
+After registration, note these values from the **Overview** page:
+- **Application (client) ID** → This is your `AZURE_AD_CLIENT_ID`
+- **Directory (tenant) ID** → This is your `AZURE_AD_TENANT_ID`
+
+### 1.3 Create a Client Secret
+
+1. Go to **Certificates & secrets** in the left menu
+2. Click **New client secret**
+3. Add a description (e.g., "Vercel Production")
+4. Choose an expiration (recommended: 24 months)
+5. Click **Add**
+6. **Immediately copy the secret value** → This is your `AZURE_AD_CLIENT_SECRET`
+   - You cannot view this value again after leaving the page!
+
+### 1.4 Configure API Permissions (Optional)
+
+The default permissions should work. If needed:
+1. Go to **API permissions**
+2. Ensure these are present:
+   - `Microsoft Graph` → `User.Read` (Delegated)
+   - `openid`, `email`, `profile` (usually included by default)
+
+### 1.5 Add Additional Redirect URIs
+
+For Vercel preview deployments, add additional redirect URIs:
+1. Go to **Authentication** in the left menu
+2. Under **Web** → **Redirect URIs**, add:
+   - `https://your-app.vercel.app/api/auth/callback/azure-ad` (production)
+   - `https://your-app-git-*.vercel.app/api/auth/callback/azure-ad` (preview deployments)
+   - `http://localhost:3000/api/auth/callback/azure-ad` (local development)
+
+**Note:** For preview deployments, you may need to use a wildcard pattern or add specific preview URLs as needed.
+
+---
+
+## Step 2: Configure Vercel Environment Variables
+
+### 2.1 Generate NEXTAUTH_SECRET
+
+Run this command to generate a secure secret:
+```bash
+openssl rand -base64 32
+```
+
+### 2.2 Add Environment Variables in Vercel
+
+1. Go to your [Vercel Dashboard](https://vercel.com/dashboard)
+2. Select your project
+3. Go to **Settings** → **Environment Variables**
+4. Add the following variables:
+
+| Variable | Value | Environments |
+|----------|-------|--------------|
+| `AUTH_REQUIRED` | `true` | Production, Preview |
+| `AZURE_AD_CLIENT_ID` | `<from Step 1.2>` | Production, Preview, Development |
+| `AZURE_AD_CLIENT_SECRET` | `<from Step 1.3>` | Production, Preview, Development |
+| `AZURE_AD_TENANT_ID` | `<from Step 1.2>` | Production, Preview, Development |
+| `NEXTAUTH_SECRET` | `<from Step 2.1>` | Production, Preview, Development |
+| `NEXTAUTH_URL` | `https://your-app.vercel.app` | Production only |
+
+**Notes:**
+- `NEXTAUTH_URL` is automatically set by Vercel for preview deployments
+- For local development, set `NEXTAUTH_URL=http://localhost:3000` in `.env.local`
+
+### 2.3 Redeploy
+
+After adding environment variables:
+1. Go to **Deployments** tab
+2. Click the three dots on the latest deployment
+3. Select **Redeploy**
+
+---
+
+## Step 3: Test the Authentication
+
+### 3.1 Test Login Flow
+
+1. Visit your app URL
+2. You should be redirected to Microsoft login
+3. Sign in with your organization account
+4. After successful login, you should see the app
+
+### 3.2 Test Organization Restriction
+
+If configured as single-tenant:
+1. Try signing in with a personal Microsoft account (outlook.com, hotmail.com)
+2. You should see an error: "You cannot access this application"
+
+### 3.3 Test API Protection
+
+With browser developer tools:
+1. Sign out of the app
+2. Try accessing an API endpoint directly: `https://your-app.vercel.app/api/user-profiles`
+3. Should return: `{"error":"Authentication required"}`
+
+---
+
+## Step 4: Kill Switch Usage
+
+The `AUTH_REQUIRED` environment variable acts as a kill switch. If you get locked out:
+
+### Disabling Authentication (Emergency Access)
+
+1. Go to Vercel Dashboard → Project → **Settings** → **Environment Variables**
+2. Find `AUTH_REQUIRED`
+3. Change value from `true` to `false`
+4. Click **Save**
+5. Go to **Deployments** → Redeploy the latest deployment
+6. Wait ~30 seconds for deployment to complete
+7. Access the app without authentication
+
+### Re-enabling Authentication
+
+1. Fix any issues with Azure AD configuration
+2. Change `AUTH_REQUIRED` back to `true`
+3. Redeploy
+
+---
+
+## Local Development
+
+### Option A: With Authentication
+
+Create `.env.local` in your project root:
+```env
+NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_SECRET=<your-secret>
+AZURE_AD_CLIENT_ID=<your-client-id>
+AZURE_AD_CLIENT_SECRET=<your-client-secret>
+AZURE_AD_TENANT_ID=<your-tenant-id>
+AUTH_REQUIRED=true
+```
+
+### Option B: Without Authentication (Development Only)
+
+For local development without Azure AD:
+```env
+AUTH_REQUIRED=false
+```
+
+This allows you to develop without setting up Azure credentials locally.
+
+---
+
+## Troubleshooting
+
+### "AADSTS50011: The reply URL specified in the request does not match"
+
+**Cause:** The redirect URI in Azure doesn't match your app URL.
+
+**Fix:**
+1. Go to Azure Portal → App Registration → Authentication
+2. Add the exact URL shown in the error message to Redirect URIs
+
+### "AADSTS700016: Application not found in the directory"
+
+**Cause:** Wrong tenant ID or the app registration was deleted.
+
+**Fix:** Verify `AZURE_AD_TENANT_ID` matches your organization's tenant.
+
+### "AADSTS50020: User account from external identity provider does not exist in tenant"
+
+**Cause:** User is trying to sign in with an account outside your organization (e.g., personal Microsoft account).
+
+**Fix:** This is expected behavior for single-tenant apps. Only organization accounts can sign in.
+
+### Users Can't Access After Login
+
+**Cause:** Session or JWT issues.
+
+**Fix:**
+1. Verify `NEXTAUTH_SECRET` is set and consistent across deployments
+2. Clear browser cookies for your app domain
+3. Try incognito/private browsing
+
+### Locked Out Completely
+
+**Fix:** Use the kill switch:
+1. Set `AUTH_REQUIRED=false` in Vercel
+2. Redeploy
+3. Debug the issue
+4. Re-enable when fixed
+
+---
+
+## Security Considerations
+
+### Single Tenant vs Multi-Tenant
+
+- **Single tenant** (recommended): Only your organization's users can sign in
+- **Multi-tenant**: Any Microsoft account can sign in (not recommended for internal apps)
+
+Verify your app registration is single-tenant in Azure Portal → App Registration → Authentication → Supported account types.
+
+### Client Secret Rotation
+
+Azure AD client secrets expire. Set a calendar reminder to rotate before expiration:
+1. Create a new secret in Azure Portal
+2. Update `AZURE_AD_CLIENT_SECRET` in Vercel
+3. Redeploy
+4. Delete the old secret in Azure Portal
+
+### Monitoring Sign-ins
+
+View sign-in logs in Azure Portal:
+1. Azure Active Directory → Sign-in logs
+2. Filter by Application = your app name
+
+---
+
+## Architecture Reference
+
+### Protected Resources
+
+| Resource | Protection Method |
+|----------|-------------------|
+| All pages | `RequireAuth` wrapper in `_app.js` |
+| API routes | `requireAuth()` in each handler |
+| Auth routes (`/api/auth/*`) | Public (required for OAuth flow) |
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `pages/_app.js` | Global auth wrapper |
+| `lib/utils/auth.js` | Server-side auth utilities |
+| `pages/api/auth/[...nextauth].js` | NextAuth configuration |
+| `pages/api/auth/status.js` | Auth status endpoint (checks kill switch) |
+| `shared/components/RequireAuth.js` | Client-side auth guard |
+
+---
+
+## Support
+
+For issues with:
+- **Azure AD configuration:** Contact your IT department
+- **App-specific issues:** Check the troubleshooting section above
+- **Vercel deployment:** See [Vercel Documentation](https://vercel.com/docs)

--- a/lib/utils/auth.js
+++ b/lib/utils/auth.js
@@ -1,11 +1,28 @@
 /**
  * Authentication utilities for API routes
  *
- * Provides server-side session checking and profile ID extraction
+ * Provides server-side session checking and profile ID extraction.
+ *
+ * Kill Switch: Set AUTH_REQUIRED=false in environment to disable auth.
+ * This allows emergency access if Azure AD credentials are misconfigured.
  */
 
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../../pages/api/auth/[...nextauth]';
+
+/**
+ * Check if authentication is required
+ * Returns false if kill switch is off or credentials are missing
+ */
+export function isAuthRequired() {
+  const hasCredentials = !!(
+    process.env.AZURE_AD_CLIENT_ID &&
+    process.env.AZURE_AD_CLIENT_SECRET &&
+    process.env.AZURE_AD_TENANT_ID
+  );
+  const authRequired = process.env.AUTH_REQUIRED === 'true';
+  return authRequired && hasCredentials;
+}
 
 /**
  * Get the authenticated session for an API route
@@ -36,6 +53,9 @@ export async function getAuthenticatedProfileId(req, res) {
  * Require authentication for an API route
  * Sends 401 response if not authenticated
  *
+ * If AUTH_REQUIRED is false (kill switch), allows all requests through
+ * with a mock session containing no user data.
+ *
  * @param {Object} req - Next.js API request
  * @param {Object} res - Next.js API response
  * @returns {Object|null} Session object or null (if 401 was sent)
@@ -50,6 +70,11 @@ export async function getAuthenticatedProfileId(req, res) {
  * }
  */
 export async function requireAuth(req, res) {
+  // Kill switch: if auth not required, allow through with empty session
+  if (!isAuthRequired()) {
+    return { user: {}, authBypassed: true };
+  }
+
   const session = await getSession(req, res);
 
   if (!session) {
@@ -64,6 +89,9 @@ export async function requireAuth(req, res) {
  * Require authentication and return profile ID
  * Sends 401 if not authenticated, 403 if no profile linked
  *
+ * If AUTH_REQUIRED is false (kill switch), falls back to userProfileId
+ * from query or body parameters (existing behavior when auth is disabled).
+ *
  * @param {Object} req - Next.js API request
  * @param {Object} res - Next.js API response
  * @returns {number|null} Profile ID or null (if error was sent)
@@ -71,7 +99,7 @@ export async function requireAuth(req, res) {
  * @example
  * export default async function handler(req, res) {
  *   const profileId = await requireAuthWithProfile(req, res);
- *   if (!profileId) return; // Error already sent
+ *   if (profileId === null) return; // Error already sent
  *
  *   // Use profileId for scoped queries
  * }
@@ -79,6 +107,12 @@ export async function requireAuth(req, res) {
 export async function requireAuthWithProfile(req, res) {
   const session = await requireAuth(req, res);
   if (!session) return null;
+
+  // If auth was bypassed, use query/body parameter (existing behavior)
+  if (session.authBypassed) {
+    const paramProfileId = req.query?.userProfileId || req.body?.userProfileId;
+    return paramProfileId ? parseInt(paramProfileId, 10) : null;
+  }
 
   const profileId = session.user?.profileId;
   if (!profileId) {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,13 +1,16 @@
 import '../styles/globals.css'
 import { SessionProvider } from 'next-auth/react'
 import { ProfileProvider } from '../shared/context/ProfileContext'
+import RequireAuth from '../shared/components/RequireAuth'
 
 export default function App({ Component, pageProps: { session, ...pageProps } }) {
   return (
     <SessionProvider session={session}>
-      <ProfileProvider>
-        <Component {...pageProps} />
-      </ProfileProvider>
+      <RequireAuth>
+        <ProfileProvider>
+          <Component {...pageProps} />
+        </ProfileProvider>
+      </RequireAuth>
     </SessionProvider>
   )
 }

--- a/pages/api/analyze-documents-simple.js
+++ b/pages/api/analyze-documents-simple.js
@@ -4,6 +4,7 @@ import { BASE_CONFIG, getModelForApp } from '../../shared/config/baseConfig';
 import { getApiKeyManager } from '../../shared/utils/apiKeyManager';
 import { applySecurityMiddleware } from '../../shared/api/middleware/security';
 import { nextRateLimiter } from '../../shared/api/middleware/rateLimiter';
+import { requireAuth } from '../../lib/utils/auth';
 
 export const config = {
   api: {
@@ -47,6 +48,10 @@ export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
+
+  // Require authentication
+  const session = await requireAuth(req, res);
+  if (!session) return;
 
   try {
     // Apply security middleware

--- a/pages/api/analyze-funding-gap.js
+++ b/pages/api/analyze-funding-gap.js
@@ -5,6 +5,7 @@ import { nextRateLimiter } from '../../shared/api/middleware/rateLimiter';
 import { createFundingExtractionPrompt, createFundingAnalysisPrompt } from '../../shared/config/prompts/funding-gap-analyzer';
 import { queryNSFforPI, queryNSFforKeywords, queryNIHforPI, queryNIHforKeywords, queryUSASpending, formatCurrency, formatDate } from '../../lib/fundingApis';
 import { getModelForApp } from '../../shared/config/baseConfig';
+import { requireAuth } from '../../lib/utils/auth';
 
 export const config = {
   api: {
@@ -26,6 +27,10 @@ export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
+
+  // Require authentication
+  const session = await requireAuth(req, res);
+  if (!session) return;
 
   // Apply rate limiting
   const rateLimitResult = await rateLimiter(req, res);

--- a/pages/api/analyze-literature.js
+++ b/pages/api/analyze-literature.js
@@ -13,6 +13,7 @@ import {
   createSynthesisPrompt,
   createComparisonPrompt
 } from '../../shared/config/prompts/literature-analyzer';
+import { requireAuth } from '../../lib/utils/auth';
 
 // Concurrency limit for processing papers
 const CONCURRENCY_LIMIT = 2;
@@ -21,6 +22,10 @@ export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
+
+  // Require authentication
+  const session = await requireAuth(req, res);
+  if (!session) return;
 
   try {
     const { files, apiKey, options = {} } = req.body;

--- a/pages/api/auth/status.js
+++ b/pages/api/auth/status.js
@@ -1,16 +1,37 @@
 /**
  * API Route: /api/auth/status
  *
- * Returns whether authentication is enabled (Azure AD configured)
- * Used by RequireAuth to determine if login should be required
+ * Returns whether authentication is enabled and required.
+ * Used by RequireAuth to determine if login should be required.
+ *
+ * Authentication is enabled when ALL of these conditions are met:
+ * 1. AUTH_REQUIRED=true (kill switch - set to false to disable auth)
+ * 2. Azure AD credentials are configured (CLIENT_ID, CLIENT_SECRET, TENANT_ID)
+ *
+ * Kill Switch Usage:
+ * - If locked out, go to Vercel Dashboard → Environment Variables
+ * - Set AUTH_REQUIRED=false and redeploy
+ * - This disables auth without changing code
  */
 
 export default function handler(req, res) {
-  const enabled = !!(
+  const hasCredentials = !!(
     process.env.AZURE_AD_CLIENT_ID &&
     process.env.AZURE_AD_CLIENT_SECRET &&
     process.env.AZURE_AD_TENANT_ID
   );
 
-  res.status(200).json({ enabled });
+  // Kill switch: AUTH_REQUIRED must be explicitly set to 'true'
+  const authRequired = process.env.AUTH_REQUIRED === 'true';
+
+  const enabled = authRequired && hasCredentials;
+
+  res.status(200).json({
+    enabled,
+    // Include details for debugging (only shows boolean flags, not secrets)
+    debug: {
+      authRequired,
+      hasCredentials,
+    },
+  });
 }

--- a/pages/api/evaluate-concepts.js
+++ b/pages/api/evaluate-concepts.js
@@ -14,6 +14,7 @@ import {
   createFinalEvaluationPrompt,
   selectDatabasesForResearchArea
 } from '../../shared/config/prompts/concept-evaluator';
+import { requireAuth } from '../../lib/utils/auth';
 
 // Import search services
 const { PubMedService } = require('../../lib/services/pubmed-service');
@@ -36,6 +37,10 @@ export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
+
+  // Require authentication
+  const session = await requireAuth(req, res);
+  if (!session) return;
 
   try {
     const { files, apiKey } = req.body;

--- a/pages/api/find-reviewers.js
+++ b/pages/api/find-reviewers.js
@@ -4,6 +4,7 @@ import { getApiKeyManager } from '../../shared/utils/apiKeyManager';
 import { nextRateLimiter } from '../../shared/api/middleware/rateLimiter';
 import { createExtractionPrompt, createReviewerPrompt, parseExtractionResponse } from '../../shared/config/prompts/find-reviewers';
 import { parseReviewers, generateReviewerCSV } from '../../shared/utils/reviewerParser';
+import { requireAuth } from '../../lib/utils/auth';
 
 export const config = {
   api: {
@@ -21,10 +22,14 @@ const rateLimiter = nextRateLimiter({
 
 export default async function handler(req, res) {
   console.log('Find Reviewers API called:', new Date().toISOString());
-  
+
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
+
+  // Require authentication
+  const session = await requireAuth(req, res);
+  if (!session) return;
 
   // Apply rate limiting
   const rateLimitResult = await rateLimiter(req, res);

--- a/pages/api/integrity-screener/dismiss.js
+++ b/pages/api/integrity-screener/dismiss.js
@@ -7,7 +7,13 @@
  * GET /api/integrity-screener/dismiss?screeningId=N - Get dismissals for a screening
  */
 
+import { requireAuth } from '../../../lib/utils/auth';
+
 export default async function handler(req, res) {
+  // Require authentication
+  const session = await requireAuth(req, res);
+  if (!session) return;
+
   try {
     const { IntegrityService } = await import('../../../lib/services/integrity-service');
 

--- a/pages/api/integrity-screener/history.js
+++ b/pages/api/integrity-screener/history.js
@@ -8,7 +8,13 @@
  * PATCH /api/integrity-screener/history - Update screening status
  */
 
+import { requireAuth } from '../../../lib/utils/auth';
+
 export default async function handler(req, res) {
+  // Require authentication
+  const session = await requireAuth(req, res);
+  if (!session) return;
+
   try {
     const { IntegrityService } = await import('../../../lib/services/integrity-service');
 

--- a/pages/api/integrity-screener/screen.js
+++ b/pages/api/integrity-screener/screen.js
@@ -10,6 +10,8 @@
  * Uses streaming SSE for real-time progress updates.
  */
 
+import { requireAuth } from '../../../lib/utils/auth';
+
 export const config = {
   api: {
     bodyParser: {
@@ -23,6 +25,10 @@ export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
+
+  // Require authentication (before setting up SSE)
+  const session = await requireAuth(req, res);
+  if (!session) return;
 
   // Set up SSE headers
   res.setHeader('Content-Type', 'text/event-stream');

--- a/pages/api/process-batch-simple.js
+++ b/pages/api/process-batch-simple.js
@@ -1,5 +1,6 @@
 import pdf from 'pdf-parse';
 import { BASE_CONFIG, getModelForApp } from '../../shared/config';
+import { requireAuth } from '../../lib/utils/auth';
 
 export const config = {
   api: {
@@ -71,6 +72,10 @@ export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
+
+  // Require authentication
+  const session = await requireAuth(req, res);
+  if (!session) return;
 
   try {
     const { files, summaryLength = 2, summaryLevel = 'technical-non-expert', apiKey } = req.body;

--- a/pages/api/process-expenses.js
+++ b/pages/api/process-expenses.js
@@ -3,6 +3,7 @@ import { createFileProcessor } from '../../shared/api/handlers/fileProcessor';
 import { getApiKeyManager } from '../../shared/utils/apiKeyManager';
 import { nextRateLimiter } from '../../shared/api/middleware/rateLimiter';
 import { getModelForApp } from '../../shared/config/baseConfig';
+import { requireAuth } from '../../lib/utils/auth';
 
 export const config = {
   api: {
@@ -104,6 +105,10 @@ export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
+
+  // Require authentication
+  const session = await requireAuth(req, res);
+  if (!session) return;
 
   // Apply rate limiting
   const rateLimitResult = await rateLimiter(req, res);

--- a/pages/api/process-peer-reviews.js
+++ b/pages/api/process-peer-reviews.js
@@ -2,11 +2,16 @@ import pdf from 'pdf-parse';
 import mammoth from 'mammoth';
 import { BASE_CONFIG, getModelForApp } from '../../shared/config';
 import { createPeerReviewAnalysisPrompt, createPeerReviewQuestionsPrompt } from '../../shared/config/prompts/peer-reviewer';
+import { requireAuth } from '../../lib/utils/auth';
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
+
+  // Require authentication
+  const session = await requireAuth(req, res);
+  if (!session) return;
 
   try {
     const { files, apiKey } = req.body;

--- a/pages/api/process-phase-i-writeup.js
+++ b/pages/api/process-phase-i-writeup.js
@@ -2,11 +2,16 @@ import pdf from 'pdf-parse';
 import { BASE_CONFIG, getModelForApp } from '../../shared/config';
 import { createPhaseIWriteupPrompt } from '../../shared/config/prompts/phase-i-writeup';
 import { createStructuredDataExtractionPrompt } from '../../shared/config/prompts/proposal-summarizer';
+import { requireAuth } from '../../lib/utils/auth';
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
+
+  // Require authentication
+  const session = await requireAuth(req, res);
+  if (!session) return;
 
   try {
     const { files, apiKey } = req.body;

--- a/pages/api/process-phase-i.js
+++ b/pages/api/process-phase-i.js
@@ -2,12 +2,17 @@ import pdf from 'pdf-parse';
 import { BASE_CONFIG, KECK_GUIDELINES, getModelForApp } from '../../shared/config';
 import { createPhaseISummarizationPrompt } from '../../shared/config/prompts/phase-i-summaries';
 import { createStructuredDataExtractionPrompt } from '../../shared/config/prompts/proposal-summarizer';
+import { requireAuth } from '../../lib/utils/auth';
 
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
+
+  // Require authentication
+  const session = await requireAuth(req, res);
+  if (!session) return;
 
   try {
     const { files, apiKey, summaryLength = 2, summaryLevel = 'technical-non-expert' } = req.body;

--- a/pages/api/process-proposals-simple.js
+++ b/pages/api/process-proposals-simple.js
@@ -5,6 +5,7 @@ import { getApiKeyManager } from '../../shared/utils/apiKeyManager';
 import { applySecurityMiddleware } from '../../shared/api/middleware/security';
 import { nextRateLimiter } from '../../shared/api/middleware/rateLimiter';
 import { createSummarizationPrompt, createStructuredDataExtractionPrompt } from '../../shared/config/prompts/proposal-summarizer';
+import { requireAuth } from '../../lib/utils/auth';
 
 export const config = {
   api: {
@@ -18,6 +19,10 @@ export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
+
+  // Require authentication
+  const session = await requireAuth(req, res);
+  if (!session) return;
 
   try {
     // Apply security middleware

--- a/pages/api/process.js
+++ b/pages/api/process.js
@@ -1,12 +1,17 @@
 import pdf from 'pdf-parse';
 import { BASE_CONFIG, getModelForApp } from '../../shared/config/baseConfig';
 import { createSummarizationPrompt, createStructuredDataExtractionPrompt } from '../../shared/config/prompts/proposal-summarizer';
+import { requireAuth } from '../../lib/utils/auth';
 
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
+
+  // Require authentication
+  const session = await requireAuth(req, res);
+  if (!session) return;
 
   try {
     const { files, apiKey, summaryLength = 2, summaryLevel = 'technical-non-expert' } = req.body;

--- a/pages/api/qa.js
+++ b/pages/api/qa.js
@@ -3,6 +3,7 @@ import { BASE_CONFIG, getModelForApp } from '../../shared/config/baseConfig';
 import { getApiKeyManager } from '../../shared/utils/apiKeyManager';
 import { applySecurityMiddleware } from '../../shared/api/middleware/security';
 import { nextRateLimiter } from '../../shared/api/middleware/rateLimiter';
+import { requireAuth } from '../../lib/utils/auth';
 
 // Q&A prompt template
 const QA_PROMPT = (context, question, filename) => `You are an expert research assistant helping analyze a research proposal. Based on the document content provided, please answer the question thoroughly and accurately.
@@ -22,6 +23,10 @@ export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
+
+  // Require authentication
+  const session = await requireAuth(req, res);
+  if (!session) return;
 
   try {
     // Apply security middleware

--- a/pages/api/refine.js
+++ b/pages/api/refine.js
@@ -3,6 +3,7 @@ import { BASE_CONFIG, getModelForApp } from '../../shared/config/baseConfig';
 import { getApiKeyManager } from '../../shared/utils/apiKeyManager';
 import { applySecurityMiddleware } from '../../shared/api/middleware/security';
 import { nextRateLimiter } from '../../shared/api/middleware/rateLimiter';
+import { requireAuth } from '../../lib/utils/auth';
 
 // Refinement prompt template
 const REFINEMENT_PROMPT = (currentSummary, feedback) => `Please refine the following research proposal summary based on the specific feedback provided. Maintain the same structure and level of detail, but improve the content according to the feedback.
@@ -27,6 +28,10 @@ export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
+
+  // Require authentication
+  const session = await requireAuth(req, res);
+  if (!session) return;
 
   try {
     // Apply security middleware

--- a/pages/api/reviewer-finder/analyze.js
+++ b/pages/api/reviewer-finder/analyze.js
@@ -13,6 +13,7 @@
  */
 
 import { put } from '@vercel/blob';
+import { requireAuth } from '../../../lib/utils/auth';
 
 export const config = {
   api: {
@@ -27,6 +28,10 @@ export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
+
+  // Require authentication (before setting up SSE)
+  const session = await requireAuth(req, res);
+  if (!session) return;
 
   // Set up SSE headers
   res.setHeader('Content-Type', 'text/event-stream');

--- a/pages/api/reviewer-finder/discover.js
+++ b/pages/api/reviewer-finder/discover.js
@@ -11,6 +11,8 @@
  * Uses streaming SSE for real-time progress updates.
  */
 
+import { requireAuth } from '../../../lib/utils/auth';
+
 // Enable verbose logging only in development with DEBUG_REVIEWER_FINDER env var
 const DEBUG = process.env.DEBUG_REVIEWER_FINDER === 'true';
 
@@ -27,6 +29,10 @@ export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
+
+  // Require authentication (before setting up SSE)
+  const session = await requireAuth(req, res);
+  if (!session) return;
 
   // Set up SSE headers
   res.setHeader('Content-Type', 'text/event-stream');

--- a/pages/api/reviewer-finder/enrich-contacts.js
+++ b/pages/api/reviewer-finder/enrich-contacts.js
@@ -18,6 +18,8 @@
  * Response: Server-Sent Events (SSE) stream with progress updates
  */
 
+import { requireAuth } from '../../../lib/utils/auth';
+
 const { ContactEnrichmentService } = require('../../../lib/services/contact-enrichment-service');
 
 export const config = {
@@ -32,6 +34,10 @@ export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
+
+  // Require authentication
+  const session = await requireAuth(req, res);
+  if (!session) return;
 
   const { candidates, credentials = {}, options = {} } = req.body;
 

--- a/pages/api/reviewer-finder/extract-summary.js
+++ b/pages/api/reviewer-finder/extract-summary.js
@@ -13,6 +13,7 @@
 import { put } from '@vercel/blob';
 import { sql } from '@vercel/postgres';
 import { extractPages } from '../../../lib/utils/pdf-extractor';
+import { requireAuth } from '../../../lib/utils/auth';
 
 export const config = {
   api: {
@@ -24,6 +25,10 @@ export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
+
+  // Require authentication
+  const session = await requireAuth(req, res);
+  if (!session) return;
 
   try {
     // Parse multipart form data

--- a/pages/api/reviewer-finder/generate-emails.js
+++ b/pages/api/reviewer-finder/generate-emails.js
@@ -27,6 +27,7 @@ import {
 } from '../../../lib/utils/email-generator';
 
 import { createPersonalizationPrompt } from '../../../shared/config/prompts/email-reviewer';
+import { requireAuth } from '../../../lib/utils/auth';
 
 /**
  * Look up proposal info for candidates from the database
@@ -119,6 +120,10 @@ export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
+
+  // Require authentication (before setting up SSE)
+  const session = await requireAuth(req, res);
+  if (!session) return;
 
   // Set up SSE headers
   res.setHeader('Content-Type', 'text/event-stream');

--- a/pages/api/reviewer-finder/grant-cycles.js
+++ b/pages/api/reviewer-finder/grant-cycles.js
@@ -8,8 +8,13 @@
  */
 
 import { sql } from '@vercel/postgres';
+import { requireAuth } from '../../../lib/utils/auth';
 
 export default async function handler(req, res) {
+  // Require authentication
+  const session = await requireAuth(req, res);
+  if (!session) return;
+
   if (req.method === 'GET') {
     return handleGet(req, res);
   } else if (req.method === 'POST') {

--- a/pages/api/reviewer-finder/my-candidates.js
+++ b/pages/api/reviewer-finder/my-candidates.js
@@ -7,8 +7,13 @@
  */
 
 import { sql } from '@vercel/postgres';
+import { requireAuth } from '../../../lib/utils/auth';
 
 export default async function handler(req, res) {
+  // Require authentication
+  const session = await requireAuth(req, res);
+  if (!session) return;
+
   if (req.method === 'GET') {
     return handleGet(req, res);
   } else if (req.method === 'PATCH') {

--- a/pages/api/reviewer-finder/researchers.js
+++ b/pages/api/reviewer-finder/researchers.js
@@ -49,8 +49,13 @@
  */
 
 import { sql } from '@vercel/postgres';
+import { requireAuth } from '../../../lib/utils/auth';
 
 export default async function handler(req, res) {
+  // Require authentication
+  const session = await requireAuth(req, res);
+  if (!session) return;
+
   if (req.method === 'GET') {
     return handleGet(req, res);
   } else if (req.method === 'POST') {

--- a/pages/api/reviewer-finder/save-candidates.js
+++ b/pages/api/reviewer-finder/save-candidates.js
@@ -8,6 +8,7 @@
 
 import { sql } from '@vercel/postgres';
 import { DatabaseService } from '../../../lib/services/database-service';
+import { requireAuth } from '../../../lib/utils/auth';
 
 /**
  * Find existing researcher using multi-field matching.
@@ -70,6 +71,10 @@ export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
+
+  // Require authentication
+  const session = await requireAuth(req, res);
+  if (!session) return;
 
   try {
     const { proposalId, proposalTitle, proposalAbstract, proposalAuthors, proposalInstitution, programArea, summaryBlobUrl, grantCycleId, userProfileId, candidates } = req.body;

--- a/pages/api/search-reviewers-pro.js
+++ b/pages/api/search-reviewers-pro.js
@@ -16,6 +16,7 @@ import { createFileProcessor } from '../../shared/api/handlers/fileProcessor';
 import { getApiKeyManager } from '../../shared/utils/apiKeyManager';
 import { nextRateLimiter } from '../../shared/api/middleware/rateLimiter';
 import { createSearchQueryPrompt, parseSearchQueryResponse } from '../../shared/config/prompts/find-reviewers';
+import { requireAuth } from '../../lib/utils/auth';
 
 // Import services (these use CommonJS exports)
 const { DatabaseService } = require('../../lib/services/database-service');
@@ -45,6 +46,10 @@ export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
+
+  // Require authentication
+  const session = await requireAuth(req, res);
+  if (!session) return;
 
   // Apply rate limiting
   const rateLimitResult = await rateLimiter(req, res);

--- a/pages/api/upload-file.js
+++ b/pages/api/upload-file.js
@@ -6,6 +6,7 @@
  */
 
 import { put } from '@vercel/blob';
+import { requireAuth } from '../../lib/utils/auth';
 
 export const config = {
   api: {
@@ -17,6 +18,10 @@ export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
+
+  // Require authentication
+  const session = await requireAuth(req, res);
+  if (!session) return;
 
   try {
     // Parse multipart form data

--- a/pages/api/upload-handler.js
+++ b/pages/api/upload-handler.js
@@ -1,4 +1,5 @@
 import { handleUpload } from '@vercel/blob/client';
+import { requireAuth } from '../../lib/utils/auth';
 
 export default async function handler(req, res) {
   // Set CORS headers
@@ -14,6 +15,10 @@ export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
+
+  // Require authentication
+  const session = await requireAuth(req, res);
+  if (!session) return;
 
   try {
     const jsonResponse = await handleUpload({

--- a/pages/api/user-preferences.js
+++ b/pages/api/user-preferences.js
@@ -9,8 +9,13 @@
  */
 
 import { DatabaseService } from '../../lib/services/database-service';
+import { requireAuth } from '../../lib/utils/auth';
 
 export default async function handler(req, res) {
+  // Require authentication
+  const session = await requireAuth(req, res);
+  if (!session) return;
+
   switch (req.method) {
     case 'GET':
       return handleGet(req, res);

--- a/pages/api/user-profiles.js
+++ b/pages/api/user-profiles.js
@@ -10,8 +10,13 @@
  */
 
 import { DatabaseService } from '../../lib/services/database-service';
+import { requireAuth } from '../../lib/utils/auth';
 
 export default async function handler(req, res) {
+  // Require authentication
+  const session = await requireAuth(req, res);
+  if (!session) return;
+
   switch (req.method) {
     case 'GET':
       return handleGet(req, res);

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,7 +2,6 @@ import { useState, useEffect } from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
 import { useSession, signOut } from 'next-auth/react';
-import RequireAuth from '../shared/components/RequireAuth';
 import ProfileSelector from '../shared/components/ProfileSelector';
 
 const apps = [
@@ -138,7 +137,6 @@ export default function LandingPage() {
   });
 
   return (
-    <RequireAuth>
       <div className="min-h-screen bg-gray-50">
         <Head>
           <title>Document Processing Suite</title>
@@ -332,7 +330,6 @@ export default function LandingPage() {
           </div>
         </footer>
       </div>
-    </RequireAuth>
   );
 }
 


### PR DESCRIPTION
## Summary

- Implement Azure AD authentication restricting app access to organization members only
- Add `AUTH_REQUIRED` environment variable as a kill switch for emergency access
- Protect all pages globally via `RequireAuth` wrapper in `_app.js`
- Add `requireAuth()` to all 31 API routes (excluding `/api/auth/*`)

## Environment Variables Required

```env
AUTH_REQUIRED=true
AZURE_AD_CLIENT_ID=<from Azure Portal>
AZURE_AD_CLIENT_SECRET=<from Azure Portal>
AZURE_AD_TENANT_ID=<organization tenant ID>
NEXTAUTH_SECRET=<generate with: openssl rand -base64 32>
```

## Kill Switch Usage

If locked out due to misconfigured Azure credentials:
1. Vercel Dashboard → Settings → Environment Variables
2. Set `AUTH_REQUIRED=false`
3. Redeploy (~30 seconds)
4. Fix the issue, then re-enable

## Test Plan

- [ ] Set environment variables on Vercel preview deployment
- [ ] Verify redirect to Microsoft login when accessing app
- [ ] Verify successful login with organization account
- [ ] Verify API routes return 401 when not authenticated
- [ ] Test kill switch: set `AUTH_REQUIRED=false` and confirm access without login
- [ ] (Optional) Verify external Microsoft accounts are rejected (if single-tenant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)