### PR TITLE
fix(test): green main — add phone to accept-path integration fixtures (422 guard)

### DIFF
--- a/tests/integration/external-review-routes.test.js
+++ b/tests/integration/external-review-routes.test.js
@@ -435,7 +435,7 @@ describe('/api/external/review/[token]/respond', () => {
       method: 'POST',
       query: { token: 'good-token' },
       headers: {},
-      body: { action: 'accept', policyAcks: { 'reviewer-coi': true, 'reviewer-ai-use': true }, address: { line1: '1 St', city: 'Town', postalCode: '94000', country: 'US' } },
+      body: { action: 'accept', policyAcks: { 'reviewer-coi': true, 'reviewer-ai-use': true }, address: { line1: '1 St', city: 'Town', postalCode: '94000', country: 'US', phone: '+1 555 0100' } },
     });
     const res = createMockRes();
     await handler(req, res);
@@ -502,7 +502,7 @@ describe('/api/external/review/[token]/respond', () => {
     verifySuggestionToken.mockResolvedValue(fresh);
     const req = createMockReq({
       method: 'POST', query: { token: 'good-token' }, headers: {},
-      body: { action: 'accept', policyAcks: { 'reviewer-coi': true, 'reviewer-ai-use': true }, address: { line1: '1 St', city: 'T', postalCode: '9', country: 'US' } },
+      body: { action: 'accept', policyAcks: { 'reviewer-coi': true, 'reviewer-ai-use': true }, address: { line1: '1 St', city: 'T', postalCode: '9', country: 'US', phone: '+1 555 0100' } },
     });
     const res = createMockRes();
     await handler(req, res);


### PR DESCRIPTION
**P0: `main`'s Tests workflow has been red since #23 merged.**

The server-side address+phone `422` guard added in `d23098c` rejects a non-opted-out accept that lacks a phone — but two integration tests in `tests/integration/external-review-routes.test.js` POSTed an address without one, so they `422` before reaching the honorarium orchestrator (CI: **1 failed suite / 159 passed**).

**Fix:** add `phone` to those two accept fixtures so they meet the new required-contact contract and reach the orchestrator as intended. No production code changes — `npx jest external-review-routes` → **22/22** green locally.

This was my miss in #23: the local jest patterns I ran didn't include this file. Merging this greens `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
