### PR TITLE
docs(reviewer): reviewer-engagement spec (Model B) + citation memory + link-permanence fixes

### DIFF
--- a/.claude-memory/MEMORY.md
+++ b/.claude-memory/MEMORY.md
@@ -20,6 +20,7 @@
 - Red CI gate or failing startup gate: feedback-red-gates-are-p0.md
 - Full `npm test` shows red (confirm it's ONLY the known bill.com expected-red set before chasing): project-bill-com-integration-tests-known-red.md
 - Scope/count/quantity claim: feedback-falsify-not-confirm.md
+- Claim about how THIS system behaves (screen/return/feature-live/field/gate/token/link), incl. in chat — cite producer, not consumer: feedback-behavior-claims-cite-the-producer.md
 - Durable docs/memory/fact edit: feedback-reconcile-dont-append-docs.md; feedback-apply-reconcile-to-fix-work.md
 - Cleanup/audit/verification loop: feedback-timebox-metawork.md
 - External platform capability claim: feedback-verify-external-platform-claims.md; feedback-cite-ground-truth.md

--- a/.claude-memory/feedback-behavior-claims-cite-the-producer.md
+++ b/.claude-memory/feedback-behavior-claims-cite-the-producer.md
@@ -1,0 +1,43 @@
+---
+name: feedback-behavior-claims-cite-the-producer
+description: Any claim about how THIS system behaves — even in conversation, not just docs — gets tagged [verified <file:line>] or [unverified]; trace the value to its PRODUCER (where it is written/returned/decided), not a consumer that reads it; a plan/design doc is NOT evidence the behavior exists. Self-policed (no hook sees chat).
+metadata:
+  type: feedback
+  status: active
+  scope: global
+  last_verified: S275 via owner-flagged failures + claude-code-guide check on hook scope
+---
+
+## Recall Rule
+
+Read this when: about to state how this system behaves — what screen a user sees, what a function returns, whether a feature is live, a field's value/semantics, a gate/branch, token/link/email behavior, "the flow is X" — in a USER-FACING MESSAGE or a doc. Not only durable artifacts: **conversation counts.**
+
+Do:
+- Tag every material behavior claim inline: `[verified <path:line>]` (I read THAT line this session) or `[unverified — assumption]`. An untagged behavior claim is, by contract, a guess — treat it (and let the owner treat it) as one.
+- Trace the value to its **PRODUCER** — the function that returns it, the line that writes the field, the predicate that decides it — not a **consumer** that reads it. Reading the caller is not reading the behavior.
+- Treat a plan / design doc / memory / SESSION_PROMPT as **intent, not state.** Verify the live code path before saying the behavior exists. (Operating Rule #1: never present plan intent as built state — applies in chat too.)
+- When you don't have the producer line handy: say "let me check" and read it, or state it `[unverified]`. Both beat a confident guess.
+
+Do not:
+- Extrapolate from a verified intermediate to an unverified terminal fact (read the consumer, assert the producer's value).
+- Quote a build-plan / memory as proof a feature is wired.
+- Make a confident behavioral assertion in design discussion just because it "tracks." Confidence is not evidence.
+
+## Why the existing guardrails didn't catch it (verified S275)
+
+- [[feedback-cite-ground-truth]] covers **external** facts (pricing, API, platform). [[feedback-falsify-not-confirm]] covers **scope/quantity** claims and is hook-enforced on `Write|Edit`. Neither covers **internal behavior** claims, and neither fires in **chat**.
+- **No hook can fire on chat prose.** Hooks key on tool events (`Bash`, `Edit`, `Write|Edit`, `Task|Agent`, `Stop/SubagentStop`) — confirmed this session via the claude-code-guide agent: hooks gate tool *actions* and can read exit codes/JSON, but cannot read a sentence I type and demand a citation. So this contract is **self-policed**, made enforceable only by visibility: the owner can flag any untagged behavior claim. A "citation-audit" subagent+SubagentStop hook was considered and rejected — it governs subagent output (not the main-loop chat where the failures happen) and can only check citation *presence*, not *correctness*.
+
+## The failures (S275, owner-flagged; eroded trust by repeated reversals)
+
+1. Claimed the reviewer portal shows the "agree-in-principle / hold" view this cycle. WRONG: `lib/external/proposal-readiness.js::isProposalReadyForReviewers()` is hardcoded `return true`, so `context.js` always dispatches the full Stage-2a accept form; HoldView is dormant. I read the **consumer** (`context.js` uses readiness) and never read the **producer** (the stubbed predicate).
+2. Claimed the reviewer magic link "stays valid 90 days throughout the process." WRONG: `pages/api/review-manager/render-emails.js` re-mints the JWT on every email containing `{{externalLink}}` and overwrites the stored hash — "latest link wins"; prior links stop verifying. Never read the mint path before asserting permanence (it was even stated in the file's own comment).
+
+Both were caught by the owner / Codex, not self-review — because self-review is blind to its own premise. Pattern identical to [[feedback-falsify-not-confirm]], but the surface is internal-behavior-in-conversation.
+
+## The rule (trigger → action)
+
+- **TRIGGER:** about to assert how this system behaves, in any user-facing text.
+- **ACTION:** (1) name the PRODUCER and confirm I read that line this session; (2) tag `[verified <file:line>]` or `[unverified]`; (3) if it's described only in a plan/doc, verify it's wired before claiming it exists. If I can't, hedge.
+
+Pair with [[feedback-cite-ground-truth]] (external facts), [[feedback-falsify-not-confirm]] (scope/quantity), [[feedback-self-review-before-delegating-review]] (provenance/lifecycle trace), and Operating Rule #1 (plan ≠ built state).

--- a/SESSION_PROMPT.md
+++ b/SESSION_PROMPT.md
@@ -1,135 +1,65 @@
-# Session 274 Prompt: Reviewer invitation demo readiness + branded-domain follow-up
+# Session 275 Prompt: Reviewer engagement build (Phase 1) + land the bundle
 
-## Session 273 Summary
+## Session 274 Summary
 
-Session 273 moved the reviewer invitation/reviewer-portal work from plan into a reusable browser testing and demo workflow. The session added local mocked Playwright rehearsals, a guarded live-email smoke path, runbook documentation, and one formatting fix found during a real test email.
+Three threads this session: (1) honorarium **capture-only** deferral + backfill (merged), (2) **email-template hub** in Profile Settings + invitation rework (merged), (3) a full **reviewer-engagement redesign → spec** plus a reliability-guardrail memory and a link-permanence doc correction (on a held, pushed, **unmerged** branch).
 
-Current branch: `codex/reviewer-invite-browser-testing`. The branch is pushed; as of session stop the working tree was clean.
+> **WHERE THE WORK IS:** the reviewer-engagement design + this handoff live on branch **`chore/reviewer-flow-docs-and-citation-memory`** (pushed, not merged). `main`'s SESSION_PROMPT stays at S274 until the bundle merges — **to resume, check out that branch.**
 
 ### What Was Completed
 
-1. **Safe browser rehearsal for Program Director invitation flow**
-   - Added `npm run rehearse:reviewer-invite:browser`, which launches a headed browser and exercises the real Workbench `Reviewers -> Candidates` UI with route-mocked reviewer/invitation APIs.
-   - This is the best demo path for colleagues: browser-visible, realistic UI, no Dataverse writes, no Dynamics email.
+1. **Honorarium capture-only deferral + backfill** — merged (PR #34)
+   - `ensureHonorariumOnboarding` returns `status:'deferred'` AFTER capturing contact+address but BEFORE minting the `akoya_request`/calling BILL, when `HONORARIUM_ONBOARDING_DEFERRED=true` OR the discriminator GUIDs are unset. No throw → no per-reviewer warning email; one non-emailing `honorarium_capture_only` notice. Address-PATCH-failure and partial-GUID-config get emailing warnings.
+   - `scripts/backfill-honorarium-capture-only.mjs` — cycle-scoped (`--cycle`), dry-run default, reuses the idempotent orchestrator.
 
-2. **Reviewer-side Playwright coverage**
-   - Expanded E2E coverage for reviewer accept and return/upload surfaces.
-   - Added `tests/e2e/program-director-invite.spec.js` for Program Director send-flow coverage.
-   - Kept reviewer portal API calls browser-mocked in E2E so SharePoint/Dataverse/Blob are not touched.
+2. **Email-template hub in Profile Settings** — merged (PR #35)
+   - "Request Abstract Email" (renamed from "Grantee Invitation Email"); new **Reviewer Emails** card (the 6-type `EmailTemplatesModal`, same pref key as Workbench); retired the dead legacy cluster (deleted `SettingsModal`, `EmailGeneratorModal`, `EmailTemplateEditor`, `EmailSettingsPanel`).
+   - Invitation reworked to surface proposal details (title/PI/co-PIs/institution/abstract) for early COI; PI = projectleader-only; co-PIs from the `wmkf_apprequestperson` junction.
 
-3. **Guarded live-email smoke tooling**
-   - Added auth capture via `npm run smoke:reviewer-invite:auth`.
-   - Added `npm run smoke:reviewer-invite:live -- prepare/open/cleanup`.
-   - Live smoke refuses to run without `LIVE_REVIEWER_EMAIL_SMOKE=true`, `--confirm-live-email`, and `TEST_REVIEWER_EMAIL_ALLOWLIST=<target email>`.
+3. **Reviewer engagement redesign → spec** — held branch (unmerged)
+   - Settled on **MODEL B (accept-now):** reviewer **accepts + onboards at the offer stage** (COI/AI acks + mailing address; honorarium capture-only), sits tight, then the PD **releases the proposal** later. The "hold / agree-in-principle" flow is **dormant** (`isProposalReadyForReviewers()` hardcoded `true`) and NOT used in this design.
+   - `docs/REVIEWER_ENGAGEMENT_SPEC.md` — Model B spine (verified vs live code) + four additions: **Release-to-reviewers**, **two reminders** (respond-by per-reviewer offset; review-due), **PD-confirmed quota** notify + selective decline (writes `withdrawn_sufficient`), **state-split token TTL** (invite=review-due cap, materials=long; no JWT extension). 4-phase sequencing; new Dataverse fields as a dependency. **Codex-vetted** (all 7 verified-citations confirmed; Part-2 findings folded in — esp. token-cap must ship WITH Release).
+   - **Link-permanence correction:** docs claimed "the URL doesn't change across the journey" — wrong; `render-emails` re-mints per email (latest-link-wins). Corrected 3 design docs + 2 email-template strings.
+   - **New always-read memory** `feedback-behavior-claims-cite-the-producer` — tag behavior claims `[verified file:line]`/`[unverified]` even in chat; read the PRODUCER not the consumer; plan ≠ built state. (Born from this session's repeated assert-without-verify failures.)
 
-4. **Live test follow-up captured**
-   - Live test email to `berets.eyeful-0f@icloud.com` worked through invite send and reviewer accept.
-   - Accepting with honorarium triggered the known alert: `WARNING — honorarium onboard failed` because `HONORARIUM_PROGRAM_ID`, `HONORARIUM_GRANTPROGRAM_ID`, and `HONORARIUM_TYPE_ID` are not configured.
-   - Cleanup deleted the smoke suggestion/person but could not delete promoted contact `c98806cf-aa6d-f111-ab0d-000d3a3065b8` (`ZZZ Smoke Test (DELETE)` / `berets.eyeful-0f@icloud.com`) because the app user lacks contact-delete permission.
-
-5. **Reviewer invite email formatting fix**
-   - Fixed excessive blank-line spacing before the CTA and centered the `Start Review` button label.
-   - The send route now normalizes repeated blank lines and keeps generated CTA HTML out of the plain-text `<br>` conversion.
-
-### Commits
-
-- `8bd92edc` - Add reviewer invite browser smoke tooling
-- `7291542e` - Expand reviewer invitation browser coverage
-- `43ac7297` - Record live reviewer smoke follow-ups
-- `08d1dd9c` - Fix reviewer invite email CTA formatting
+### Commits — branch `chore/reviewer-flow-docs-and-citation-memory` (pushed, UNMERGED)
+- `586d5be8` citation/producer-trace memory
+- `ff3c5a1a` link-permanence doc/copy corrections
+- `c04bc647` Codex Model-B interpretation snapshot
+- `ca0b92ac` reviewer engagement spec
+- `18933df3` spec revised per Codex sanity pass
+- (+ this SESSION_PROMPT commit)
+- Merged to `main` earlier this session: **PR #34** (honorarium), **PR #35** (email hub).
 
 ## Potential Next Steps
 
-### 1. Demo the safe browser rehearsal
+### 1. Land the bundle
+Open a PR for `chore/reviewer-flow-docs-and-citation-memory` → `main` and merge. It's design/docs + the reliability memory + link-permanence fixes — all low-risk, no behavior change.
 
-Use this first for colleagues:
+### 2. Reviewer-engagement build (GATED on Dataverse schema)
+Per `docs/REVIEWER_ENGAGEMENT_SPEC.md` §4, the new Dataverse fields (campaign config on `akoya_request` + `wmkf_respondremindersentat` on the suggestion) must be created first — **line this up with Connor.** Then build in order:
+- **Phase 1:** per-request campaign config (discrete columns) + panel "days to respond" (offset) change. No token behavior change yet.
+- **Phase 2:** Release-to-reviewers action + token TTL (ship together) + the upload `materials_sent` guard.
+- **Phase 3:** two reminders (daily cron) + `wmkf_respondremindersentat`.
+- **Phase 4:** quota count-after-write + conditional notify + PD selective decline.
 
-```bash
-npm run rehearse:reviewer-invite:browser
-```
-
-Expected: headed browser opens the Program Director invitation workflow, sends through mocked routes, and opens a local reviewer portal link without real external side effects.
-
-### 2. Re-run automated reviewer E2E coverage
-
-```bash
-npx playwright test \
-  tests/e2e/reviewer-accept.spec.js \
-  tests/e2e/reviewer-captured-invite.spec.js \
-  tests/e2e/reviewer-return-upload.spec.js \
-  --project=chromium
-```
-
-Optional Program Director-focused E2E:
-
-```bash
-npx playwright test tests/e2e/program-director-invite.spec.js --project=chromium
-```
-
-### 3. Prepare for another live-email smoke only when intended
-
-Use only with a test address the owner controls:
-
-```bash
-npm run smoke:reviewer-invite:auth -- --base-url https://wmkfresearch.vercel.app
-
-TEST_REVIEWER_EMAIL_ALLOWLIST=berets.eyeful-0f@icloud.com \
-LIVE_REVIEWER_EMAIL_SMOKE=true \
-npm run smoke:reviewer-invite:live -- prepare \
-  --email berets.eyeful-0f@icloud.com \
-  --confirm-live-email
-
-TEST_REVIEWER_EMAIL_ALLOWLIST=berets.eyeful-0f@icloud.com \
-LIVE_REVIEWER_EMAIL_SMOKE=true \
-npm run smoke:reviewer-invite:live -- open \
-  --base-url https://wmkfresearch.vercel.app \
-  --auth-state .auth/reviewer-invite-smoke.json \
-  --confirm-live-email
-```
-
-Afterward:
-
-```bash
-npm run smoke:reviewer-invite:live -- cleanup
-```
-
-### 4. Fix operational follow-ups before broader live testing
-
-- Ask a Dataverse admin to delete promoted contact `c98806cf-aa6d-f111-ab0d-000d3a3065b8` if it still exists.
-- Configure honorarium discriminator env vars by running `scripts/probe-honorarium-discriminators.js` against the target Dataverse environment, then set `HONORARIUM_PROGRAM_ID`, `HONORARIUM_GRANTPROGRAM_ID`, and `HONORARIUM_TYPE_ID`.
-- As of S274, an unconfigured environment (or `HONORARIUM_ONBOARDING_DEFERRED=true`) auto-defers to **capture-only**: the reviewer's contact + mailing address are captured, no `akoya_request` is minted, and NO per-reviewer `honorarium_onboard_failed` email fires (one non-emailing `honorarium_capture_only` notice is recorded instead). So live-smoke reviewers no longer need to opt out to avoid alert spam. To re-enable honorarium-record creation, set all three GUID vars **and** ensure `HONORARIUM_ONBOARDING_DEFERRED` is not `true` (the explicit flag is checked first, so it overrides configured GUIDs). Setting only some of the GUIDs (without the flag) fires a deduped `honorarium_discriminator_partial_config` warning, and a failed address write in capture-only mode fires a `honorarium_capture_failed` warning rather than silently losing the address.
-- When IT finishes Cloudflare DNS, set `REVIEWER_PORTAL_BASE_URL=https://reviews.wmkeck.org` in the relevant Vercel environment and redeploy.
+### 3. Model-B invitation copy fix (small, anytime)
+The shipped invitation copy still says "no commitment today, COI/AI + honorarium come later" (Model A). Change to "you confirm COI/AI + honorarium details when you accept; the proposal follows later." See SPEC §5.
 
 ## Key Files Reference
 
 | File | Purpose |
 |------|---------|
-| `docs/REVIEWER_E2E_REHEARSAL_RUNBOOK.md` | Canonical reviewer testing/demo runbook, including no-send local rehearsal and live-email smoke steps |
-| `scripts/rehearse-pd-invite-browser.mjs` | Headed browser mock harness for Program Director invite demo |
-| `scripts/save-playwright-auth-state.mjs` | Saves authenticated Playwright browser state for deployed-app smoke tests |
-| `scripts/live-reviewer-invite-smoke.mjs` | Guarded prepare/open/cleanup wrapper for real email smoke testing |
-| `tests/e2e/program-director-invite.spec.js` | Program Director invitation browser coverage |
-| `tests/e2e/reviewer-accept.spec.js` | Reviewer accept flow coverage |
-| `tests/e2e/reviewer-captured-invite.spec.js` | Captured email button -> reviewer portal coverage |
-| `tests/e2e/reviewer-return-upload.spec.js` | Reviewer return/upload flow coverage |
-| `pages/api/review-manager/send-emails.js` | Reviewer invite email HTML formatting and CTA rendering |
-| `tests/integration/send-emails-route.test.js` | Send-route capture, production-refusal, CTA formatting regression coverage |
+| `docs/REVIEWER_ENGAGEMENT_SPEC.md` | The build spec — Model B + 4 additions, phases, schema, edge cases |
+| `docs/REVIEWER_ENGAGEMENT_PLAN_INTERPRETATION.md` | Codex's Model-B flow interpretation (mermaid + open questions) |
+| `lib/bill/honorarium-onboard-orchestrator.js` | Honorarium capture-only deferral tier |
+| `scripts/backfill-honorarium-capture-only.mjs` | Go-live backfill for capture-only reviewers |
+| `pages/profile-settings.js` | Email-template hub (signature, Request Abstract, Reviewer Emails) |
+| `.claude-memory/feedback-behavior-claims-cite-the-producer.md` | Reliability guardrail (cite the producer) |
 
-## Testing Performed In Session 273
+## Gotchas / Continuity
 
-```bash
-npx jest tests/integration/send-emails-route.test.js --runInBand
-npx eslint pages/api/review-manager/send-emails.js tests/integration/send-emails-route.test.js
-```
-
-Observed: focused send-route suite passed (`16 passed`), and ESLint passed for touched email-formatting files.
-
-Additional browser/live validation was performed interactively during the session and recorded in `docs/REVIEWER_E2E_REHEARSAL_RUNBOOK.md`.
-
-## Continuity Guardrails
-
-- Do not set `EMERGENCY_AUTH_BYPASS=true` for these tests. Use normal staff sign-in or the local mocked harness.
-- `REVIEWER_EMAIL_DELIVERY_MODE=capture` is non-production only; production should remain `send`.
-- Live smoke sends real mail on the final manual send click.
-- The current reviewer custom domain is pending Cloudflare/IT. Until DNS/env are cut over, real links may still use the Vercel host.
-- The `applications.wmkeck.org`, `submissions.wmkeck.org`, and `grantees.wmkeck.org` naming discussion is still a planning item; this session only built/tested reviewer invitation workflows.
+- **Reviewer flow is Model B (accept-now) LIVE today** because `lib/external/proposal-readiness.js::isProposalReadyForReviewers()` returns hardcoded `true`; the HoldView path is dormant. Don't reintroduce the hold/finalize two-step.
+- **Reviewer secure links are NOT stable across emails** — `render-emails` re-mints per email; "latest link wins." Use the link in the most recent email.
+- **Honorarium is capture-only this cycle** (discriminator GUIDs unset) — address captured, no `akoya_request` minted, no per-reviewer alert.
+- The held branch is the source of truth for the reviewer-engagement work; the two interpretation/spec `.md` files supersede each other in that order.

--- a/docs/REVIEWER_ENGAGEMENT_PLAN_INTERPRETATION.md
+++ b/docs/REVIEWER_ENGAGEMENT_PLAN_INTERPRETATION.md
@@ -1,0 +1,131 @@
+# Reviewer Engagement Plan Interpretation
+
+## Mermaid Flowchart
+
+```mermaid
+flowchart TD
+  subgraph PD["PD Actor"]
+    PD1["Send invite [LIVE TODAY]"]
+    PD2["Re-invite [LIVE TODAY]"]
+    PD3["Release materials button [TO-BUILD]"]
+    PD4["Send materials manually [LIVE TODAY]"]
+    PD5["Receives quota notice [TO-BUILD]"]
+    PD6["Withdraws pending reviewer [TO-BUILD]"]
+  end
+
+  subgraph Reviewer["Reviewer Actor"]
+    R1["Opens portal [LIVE TODAY]"]
+    R2["Accepts with acks [LIVE TODAY]"]
+    R3["Provides address [LIVE TODAY]"]
+    R4["Sits tight [LIVE TODAY]"]
+    R5["Receives materials [LIVE TODAY]"]
+    R6["Submits review [LIVE TODAY]"]
+    R7["Declines invite [LIVE TODAY]"]
+    R8["Sees no longer needed [LIVE TODAY]"]
+    R9["Gets respond reminder [TO-BUILD]"]
+    R10["Gets due reminder [TO-BUILD]"]
+  end
+
+  subgraph System["System / Crons / State"]
+    S1["Persist config [TO-BUILD]"]
+    S2["Mint 90d token [LIVE TODAY]"]
+    S3["Mint due-grace token [TO-BUILD]"]
+    S4["Stamp emailSentAt [LIVE TODAY]"]
+    S5["Verify reused token [LIVE TODAY]"]
+    S6["Dispatch Stage2a [LIVE TODAY]"]
+    S7["Write accepted [LIVE TODAY]"]
+    S8["Capture honorarium info [LIVE TODAY]"]
+    S9["Extend token 90d [TO-BUILD]"]
+    S10["Count accepted [TO-BUILD]"]
+    S11["Quota threshold? [TO-BUILD]"]
+    S12["Notify PD once [TO-BUILD]"]
+    S13["Write withdrawn sufficient [TO-BUILD]"]
+    S14["Cancel respond reminder [TO-BUILD]"]
+    S15["Send materials email [LIVE TODAY]"]
+    S16["Mark materials sent [LIVE TODAY]"]
+    S17["Write review received [LIVE TODAY]"]
+    S18["Respond reminder cron [TO-BUILD]"]
+    S19["Review due cron [TO-BUILD]"]
+    S20["Stop if responded [TO-BUILD]"]
+    S21["Sweep no response [LIVE TODAY]"]
+  end
+
+  PD1 --> S1
+  PD1 --> S2
+  PD1 --> S3
+  S2 --> S4
+  S3 --> S4
+  PD2 --> S2
+  PD2 --> S4
+
+  S4 --> R1
+  R1 --> S5
+  S5 --> S6
+  S6 --> R2
+  R2 --> R3
+  R3 --> S7
+  S7 --> S8
+  S8 --> S9
+  S9 --> R4
+  S9 --> S10
+  S10 --> S11
+  S11 --> S12
+  S12 --> PD5
+
+  PD5 --> PD6
+  PD6 --> S13
+  S13 --> S14
+  S13 --> R8
+
+  S18 --> S20
+  S20 --> R9
+  R9 --> R1
+
+  R2 --> R7
+  R7 --> S20
+
+  R4 --> PD3
+  R4 --> PD4
+  PD3 --> S15
+  PD4 --> S15
+  S15 --> S16
+  S16 --> R5
+
+  S19 --> R10
+  R10 --> R6
+  R5 --> R6
+  R6 --> S17
+
+  S21 --> S5
+  S21 --> S13
+```
+
+## Open Questions / Ambiguities / Gaps
+
+1. Quota counting needs exact semantics: count only currently accepted reviewers, or include materials-sent, submitted, held, opted-out, withdrawn, and later-flipped reviewers?
+
+2. Quota notification race handling is unclear: simultaneous accepts could cross the threshold twice unless the "notify PD once" state is persisted atomically.
+
+3. Respond-by reminder behavior after the deadline is ambiguous: should a missed lead window still send late, or should reminders stop once the response deadline passes?
+
+4. Respond-by reminder persistence needs a separate marker because today's `wmkf_remindersentat`/count are used for review follow-up reminders.
+
+5. Token extension timing is underspecified: a signed JWT's expiry cannot truly be extended in place, so accepting likely requires minting a replacement token and deciding how the reviewer receives or navigates to it.
+
+6. Multi-wave re-invite rules need detail: re-stamped `emailSentAt` should re-arm respond reminders, but it is unclear whether it also re-mints tokens, resets prior reminder markers, or preserves campaign config.
+
+7. Campaign config editability is undefined after invite send: the plan needs where PDs edit respond offset, review due, reminder settings, and desired count, plus whether edits affect already-invited reviewers.
+
+8. `withdrawn_sufficient` and honorarium interaction is unclear: it should target pending reviewers, but the plan should state whether it blocks honorarium/payment work if applied to an already accepted row by mistake.
+
+9. `sweep-stale-invites` may conflict with new token TTL policy: meeting-date-based no-response closure and review-due-based token expiry can disagree unless one becomes authoritative.
+
+10. Materials release needs a server-side accepted-only gate: the new PD button wraps the live manual materials send, but the plan should specify whether non-accepted selected reviewers are skipped or rejected.
+
+11. Review-due reminders need target refinement: "accepted but not submitted" could include accepted-pre-materials reviewers who have not yet received materials.
+
+12. The plan does not specify the durable schema for campaign config, quota-notified state, respond-reminded state, or per-request desired count.
+
+13. Existing render behavior can mint a fresh external link whenever `{{externalLink}}` appears, so reminder templates must be constrained if the intended model is one reused engagement token.
+
+14. `scripts/cron/` was [NOT FOUND]; live cron code is under `pages/api/cron/`, so the implementation target should be named consistently.

--- a/docs/REVIEWER_ENGAGEMENT_SPEC.md
+++ b/docs/REVIEWER_ENGAGEMENT_SPEC.md
@@ -1,0 +1,109 @@
+# Reviewer Engagement Spec — Model B (accept-now) + reminders, quota, token TTL
+
+**Status:** design, ready for Codex sanity pass (S275). Supersedes the interpretation snapshot in `REVIEWER_ENGAGEMENT_PLAN_INTERPRETATION.md`.
+
+**Citation convention:** current-behavior claims carry `[verified <file>::<symbol>]` (read this session). Planned work is `[BUILD]`. New Dataverse fields are `[SCHEMA]`. Settled design calls are `[DECISION]`.
+
+---
+
+## 1. Model — "accept now, proposal later"
+
+A reviewer is invited, **accepts (or declines) the offer with full onboarding at the offer stage** (COI/AI acks + mailing address; honorarium captured), then sits tight until the PD **releases the proposal**, then reviews. There is **one** reviewer decision (accept/decline) — no "agree in principle / finalize" two-step.
+
+> The dormant "hold / agree-in-principle" path (`HoldView`, `respond.js` hold action) is **NOT** part of this design. It exists but never fires because the readiness gate is stubbed (below). We leave it dormant.
+
+---
+
+## 2. Verified current state (the spine — already live)
+
+| # | Behavior | Evidence |
+|---|---|---|
+| 2.1 | Readiness gate is stubbed to always-ready, so every reviewer is dispatched to the full Stage-2a accept form (the hold view never shows). | `[verified lib/external/proposal-readiness.js::isProposalReadyForReviewers]` returns hardcoded `true`; `[verified pages/api/external/review/[token]/context.js::computeEngagementState]` `view = isReady ? 'stage2a' : 'hold-invite'` |
+| 2.2 | A fresh non-opted-out accept requires COI + AI policy acks (400 if missing) and a mailing address + phone (422 if missing); writes `accepted` + acks; lands in `accepted-pre-materials`. | `[verified pages/api/external/review/[token]/respond.js handler]` (policy_ack_required, payment_contact_required, applyStage2aResponse accept) |
+| 2.3 | Honorarium onboarding at accept is **capture-only this cycle** (captures contact + address, mints no `akoya_request`, no per-reviewer alert). | `[verified lib/bill/honorarium-onboard-orchestrator.js::ensureHonorariumOnboarding]` (deferred tier, shipped earlier S274) |
+| 2.4 | The invitation is the only sendable first-contact email. | `[verified shared/components/reviewers/InviteEmailModal.js]` hardcoded `templateType:'invitation'`; manage modal exposes only materials/followup/thankyou `[verified shared/components/reviewers/ReviewerManagePanel.js]` |
+| 2.5 | `emailSentAt` is stamped per-suggestion at invite send, re-stamped on Re-invite. | `[verified pages/api/review-manager/send-emails.js]` (invitation/hold branch: `invited:true, emailSentAt:now`); Re-invite via `allowResend` `[verified lib/utils/reviewer-invite.js::shouldSkipDuplicateInvitation]` |
+| 2.6 | The secure token is a signed JWT; **only its hash is stored**; the send path **re-mints on every email containing `{{externalLink}}` and overwrites the hash** ("latest link wins" — prior links stop verifying). | `[verified pages/api/review-manager/render-emails.js]` (`needsExternalLink` → `mintAndStore`, comment "the email body becomes the canonical link"); `[verified lib/external/token-lifecycle.js::mintAndStore]`, `[verified lib/services/external-token.js::mintToken]` (JWT `exp` = `expiresAt`) |
+| 2.7 | `verify-suggestion-token` enforces JWT signature/expiry + stored hash + revoked flag + stored `wmkf_externaltokenexpires`. | `[verified lib/external/verify-suggestion-token.js]` |
+| 2.8 | Proposal/materials are sent **manually** today (no auto-send, no release action, no cron). | `[verified]` no cron in `pages/api/cron/` sends materials; materials send is the manual ReviewerManagePanel "Materials" path |
+| 2.9 | `withdrawn_sufficient` (responseType `100000003`) has a portal "no longer needed" view + a respond guard, but **nothing writes it**. | view `[verified context.js]` `view='withdrawn-sufficient'`; guard `[verified respond.js]` 409 `withdrawn_sufficient`; **no writer** `[verified grep — no set of `wmkf_withdrawnsufficientat`]` |
+| 2.10 | `sweep-stale-invites` closes non-responders to `no_response` **after the meeting date** (not respond-by). | `[verified pages/api/cron/sweep-stale-invites.js]`, `[verified lib/services/reviewer-suggestion-sweep.js]` |
+| 2.11 | The 3 invite dates (respond-by / proposal-delivery / review-due) are a **sticky USER preference + email body text only** — NOT persisted per reviewer or request. Respond-by tokens are client-substituted and line-dropped when blank. | `[verified InviteEmailModal.js]` `PREFERENCE_KEYS.INVITE_TIMING`, `applyTiming` |
+
+---
+
+## 3. The build — four additions on top of the spine
+
+All four ride on existing mechanisms; none requires a parallel route or a new token primitive.
+
+### 3.A  Release to reviewers `[BUILD]`
+A PD action that **emails the proposal/materials to the ACCEPTED reviewers**. It is a clean wrapper over the existing manual Materials send — NOT a readiness/hold mechanism.
+- **Target:** `wmkf_accepted = true` rows only, enforced **server-side** `[DECISION #10]` (reuse the materials-send recipient gate).
+- **Token effect:** the materials email re-mints a fresh, **long-lived** token (§3.D). This is the link accepted reviewers use to review; it supersedes their invite link `[verified §2.6 latest-link-wins]`.
+
+### 3.B  Two reminders (daily cron in `pages/api/cron/`) `[BUILD]` `[DECISION #14]`
+Each reminder is **off by default** with a configurable "days before."
+
+**Respond-by reminder** — nudge invited non-responders.
+- Target: `invited && no response` (not accepted/declined/withdrawn).
+- Per-reviewer deadline = **that reviewer's `emailSentAt` + `respondOffsetDays`** (computed in code; OData can't do the arithmetic — same pattern as the sweep). `[verified §2.5 emailSentAt is per-suggestion]`
+- Fire **once**, when `today ≥ (deadline − leadDays)`, reviewer still unresponded, token not expired, `wmkf_respondremindersentat` empty. If already past the soft date at first eligibility, send once anyway (a late nudge is fine — respond-by is soft). Never repeat. `[DECISION #3]`
+- Marker: new per-suggestion `wmkf_respondremindersentat` `[SCHEMA]`, **separate** from the review-due/follow-up marker. `[DECISION #4]`
+- The reminder email contains `{{externalLink}}` → it **re-mints** a fresh token with the SAME invite cap (review-due + grace). Reviewers use the most recent link. `[DECISION #13, verified §2.6]`
+
+**Review-due reminder** — nudge accepted reviewers who haven't submitted.
+- Target: `accepted && materials-sent && not-submitted` — never an accepted-pre-materials reviewer who hasn't received the proposal. `[DECISION #11]`
+- Deadline = the fixed review-due date − leadDays.
+- This automates today's manual `followup` template `[verified §2.4]`; do not also keep a manual review-due reminder.
+
+### 3.C  Quota → notify PD → selective decline `[BUILD]`
+**Not automatic.** Reaching the desired count notifies the PD, who decides who (if anyone) to decline — so a wanted-but-slow senior reviewer is never auto-shut-out.
+- Count = `wmkf_accepted = true` rows for the request (any downstream stage). `[DECISION #1]`
+- On each accept (`respond.js` accept path), compare count to `desiredCount`; on the false→set transition of `wmkf_quotanotifiedat` `[SCHEMA]`, notify the PD once (first-writer-wins; a rare double-notify is harmless). `[DECISION #2]`
+- PD action (Workbench): select pending invitees and send the polite "no longer needed" decline → sets `withdrawn_sufficient` + `wmkf_withdrawnsufficientat` (the missing writer from §2.9) + sends the decline email + clears those reviewers' `wmkf_respondremindersentat` so no reminder fires.
+- `withdrawn_sufficient` is settable **only on still-pending rows** (`invited && !accepted && !declined`), server-guarded; it never touches an accepted/honorarium row. `[DECISION #8]`
+
+### 3.D  Token TTL — non-responders expire early, accepted keep ~90 days `[BUILD]`
+No JWT "extension" (a signed JWT can't be extended in place; the raw token isn't stored). We use the existing latest-link-wins re-mint:
+- **Invite send** (and respond-by reminder re-mint): mint with **expiry = review-due + grace** (default grace 1–2 days). This is the non-responder cap — their link dies at review-due. `[DECISION #5]`
+- **Release/materials send**: mints a fresh, **long-lived** token (expiry ≈ review-due + ~90 days) for the review window + late returns. Only ACCEPTED reviewers ever receive this, so non-responders never get the long token. `[DECISION #1 late-returns-OK]`
+- Requires `render-emails` to pick the expiry by template/config (it currently hardcodes `now + 90`); the review-due date must be available at mint (→ §4 persistence). `[verified §2.6 render-emails mints]`
+- `sweep-stale-invites` (meeting-date) and the token cap (review-due) are **different gates** and both stay: the token cap is the **access** gate (link stops working at review-due); the sweep is **status** bookkeeping (`no_response` at meeting date). No conflict. `[DECISION #9]`
+
+### 3.E  Per-request campaign config + panel change `[BUILD]` `[SCHEMA]`
+Persist, on the request, what the cron and quota logic need (today these are throwaway `[verified §2.11]`):
+- `respondOffsetDays` (default 7), `reviewDueDate` (fixed), `respondReminderEnabled` + `respondReminderLeadDays`, `reviewDueReminderEnabled` + `reviewDueReminderLeadDays`, `desiredCount`, `quotaNotifiedAt`.
+- Written on first invite-batch send; **editable later** from the Reviewers tab; read live by the cron. Edits apply going forward, not retroactively. `[DECISION #7]`
+- **Panel change:** the respond-by input becomes **"days to respond" (offset)**, not a fixed date `[DECISION — fixes the multi-wave bug where a fixed day-0 date shortchanges later waves]`; review-due stays a fixed date; proposal-delivery stays informational email text only (no reminder — `[DECISION]` dropped).
+- Multi-wave / Re-invite: a new wave is a normal first-time invite (its own `emailSentAt`); a Re-invite re-mints (review-due cap), re-stamps `emailSentAt`, and **clears `wmkf_respondremindersentat`**; request-level config is untouched. `[DECISION #6]`
+
+---
+
+## 4. Schema additions `[SCHEMA]` — DEPENDENCY (Dataverse fields must be created)
+
+On `akoya_request` (or a single JSON config field `wmkf_reviewcampaignconfig` — decide at build):
+`respond_offset_days`, `review_due_date`, `respond_reminder_enabled`, `respond_reminder_lead_days`, `reviewdue_reminder_enabled`, `reviewdue_reminder_lead_days`, `desired_count`, `quota_notified_at`.
+
+On `wmkf_appreviewersuggestion`:
+`wmkf_respondremindersentat` (datetime).
+
+> These are new fields — a real dependency (Dataverse admin / migration), not just code. The cron filters need them queryable, which favors discrete fields over a JSON blob for the ones the cron filters on (`reminder_enabled`, dates); the rest can be JSON.
+
+---
+
+## 5. Sequencing
+
+- **Phase 1 — Persistence + panel + token cap:** campaign config on the request; panel "days to respond" change; `render-emails` picks token expiry from config (invite = review-due + grace, materials = long). Foundation for everything else.
+- **Phase 2 — Reminders:** the two-reminder daily cron + the `wmkf_respondremindersentat` marker.
+- **Phase 3 — Release + Quota:** the accepted-only Release action; quota count/notify in the accept path; the PD selective-decline Workbench action (writes `withdrawn_sufficient`).
+
+Independent of all of the above: the invitation copy still needs the **Model-B fix** (the shipped copy says "no commitment today, COI/AI + honorarium come later" — wrong; should say "you confirm COI/AI + honorarium details when you accept; the proposal follows later"). Small, do anytime.
+
+---
+
+## 6. Risks / notes
+
+- **Honorarium stays capture-only** this cycle `[verified §2.3]`; none of this changes that.
+- **Token cap depends on a sane review-due date** in the config; if absent, fall back to the current `now + 90` (don't silently mint a past-dated/expired token).
+- **Latest-link-wins is now explicit** `[verified §2.6]`: every reminder/materials email supersedes prior links; reviewer-facing copy already corrected (S275) to "use the link in this email."
+- **Quota count runs in the external accept path** (`respond.js`) — a Dataverse count query per accept; acceptable (low volume), guard the notify with the first-writer flag.

--- a/docs/REVIEWER_ENGAGEMENT_SPEC.md
+++ b/docs/REVIEWER_ENGAGEMENT_SPEC.md
@@ -49,7 +49,8 @@ Each reminder is **off by default** with a configurable "days before."
 - Per-reviewer deadline = **that reviewer's `emailSentAt` + `respondOffsetDays`** (computed in code; OData can't do the arithmetic — same pattern as the sweep). `[verified §2.5 emailSentAt is per-suggestion]`
 - Fire **once**, when `today ≥ (deadline − leadDays)`, reviewer still unresponded, token not expired, `wmkf_respondremindersentat` empty. If already past the soft date at first eligibility, send once anyway (a late nudge is fine — respond-by is soft). Never repeat. `[DECISION #3]`
 - Marker: new per-suggestion `wmkf_respondremindersentat` `[SCHEMA]`, **separate** from the review-due/follow-up marker. `[DECISION #4]`
-- The reminder email contains `{{externalLink}}` → it **re-mints** a fresh token with the SAME invite cap (review-due + grace). Reviewers use the most recent link. `[DECISION #13, verified §2.6]`
+- The reminder email contains `{{externalLink}}` → it **re-mints** a fresh token with the SAME invite cap (review-due + grace), invalidating the prior invite link. Reviewers use the most recent link. `[DECISION #13, verified §2.6]` **Required copy fix (Codex P2):** the portal's expired-link error says "most recent **invitation** email" (`pages/external/review/[token].js`) — change to "most recent email," since a reminder (not the invitation) may now carry the live link.
+- **Required side-effect (Codex P2):** Re-invite (`allowResend`) MUST clear `wmkf_respondremindersentat` in the **same write** as the `emailSentAt` re-stamp (`send-emails.js` invitation branch), or the fire-once marker from the prior wave blocks the new window's reminder. Build the marker with this in mind from the start.
 
 **Review-due reminder** — nudge accepted reviewers who haven't submitted.
 - Target: `accepted && materials-sent && not-submitted` — never an accepted-pre-materials reviewer who hasn't received the proposal. `[DECISION #11]`
@@ -58,8 +59,8 @@ Each reminder is **off by default** with a configurable "days before."
 
 ### 3.C  Quota → notify PD → selective decline `[BUILD]`
 **Not automatic.** Reaching the desired count notifies the PD, who decides who (if anyone) to decline — so a wanted-but-slow senior reviewer is never auto-shut-out.
-- Count = `wmkf_accepted = true` rows for the request (any downstream stage). `[DECISION #1]`
-- On each accept (`respond.js` accept path), compare count to `desiredCount`; on the false→set transition of `wmkf_quotanotifiedat` `[SCHEMA]`, notify the PD once (first-writer-wins; a rare double-notify is harmless). `[DECISION #2]`
+- Count = `wmkf_accepted = true` rows for the request (any downstream stage), queried **AFTER** the accept PATCH commits (`applyStage2aResponse` runs first in `respond.js`; a pre-write count is off by one) `[DECISION #1, Codex P2]`. Reuse the existing accepted-reader filter shape (`lib/dataverse/adapters/reviewer-suggestion.js::findAcceptedByPD` uses `wmkf_accepted eq true`).
+- **Concurrency mechanism (named, Codex P1):** the notify must be a **conditional null→set** of `wmkf_quotanotifiedat` `[SCHEMA]` via an `If-Match`/ETag update (`DynamicsService.updateRecord` supports `ifMatch`), so only the first writer past the threshold succeeds and notifies; concurrent accepts that lose the race do not double-notify. Notify the PD on that single false→set transition. (Without the conditional write, concurrent accepts can both notify, and a stale count read can miss the threshold until a later accept — so the conditional set is required, not optional.)
 - PD action (Workbench): select pending invitees and send the polite "no longer needed" decline → sets `withdrawn_sufficient` + `wmkf_withdrawnsufficientat` (the missing writer from §2.9) + sends the decline email + clears those reviewers' `wmkf_respondremindersentat` so no reminder fires.
 - `withdrawn_sufficient` is settable **only on still-pending rows** (`invited && !accepted && !declined`), server-guarded; it never touches an accepted/honorarium row. `[DECISION #8]`
 
@@ -68,7 +69,9 @@ No JWT "extension" (a signed JWT can't be extended in place; the raw token isn't
 - **Invite send** (and respond-by reminder re-mint): mint with **expiry = review-due + grace** (default grace 1–2 days). This is the non-responder cap — their link dies at review-due. `[DECISION #5]`
 - **Release/materials send**: mints a fresh, **long-lived** token (expiry ≈ review-due + ~90 days) for the review window + late returns. Only ACCEPTED reviewers ever receive this, so non-responders never get the long token. `[DECISION #1 late-returns-OK]`
 - Requires `render-emails` to pick the expiry by template/config (it currently hardcodes `now + 90`); the review-due date must be available at mint (→ §4 persistence). `[verified §2.6 render-emails mints]`
-- `sweep-stale-invites` (meeting-date) and the token cap (review-due) are **different gates** and both stay: the token cap is the **access** gate (link stops working at review-due); the sweep is **status** bookkeeping (`no_response` at meeting date). No conflict. `[DECISION #9]`
+- `sweep-stale-invites` (meeting-date) and the token cap (review-due) are **different gates** and both stay: the token cap is the **access** gate (link stops working at review-due); the sweep is **status** bookkeeping (`no_response` at meeting date). No conflict — but note a **staff-UI gap (Codex P2):** between review-due and meeting-date a row reads "pending/invited" in the UI while its link can no longer respond. Surface "link expired" state in the staff view, or tighten the sweep toward review-due. `[DECISION #9]`
+- **"Accepted but never released" window (Codex P1):** an accepted-pre-materials reviewer holds only the **invite** token (review-due cap). If the PD never sends materials, that link dies at review-due with no self-serve path. Mitigation: (a) the Release action MUST ship with the cap (see §5 reordering) so the long-lived materials link normally exists before the cap bites; (b) the existing **regenerate-token** staff endpoint (`lib/external/token-lifecycle.js`) is the recovery path for any stranded reviewer.
+- **Cap is "going forward" only (Codex P2):** `mintToken` fixes `exp` at mint time; changing `reviewDueDate` in the config later does NOT re-cap already-minted tokens. Acceptable — recovery is a re-invite / materials send / regenerate-token, all of which re-mint.
 
 ### 3.E  Per-request campaign config + panel change `[BUILD]` `[SCHEMA]`
 Persist, on the request, what the cron and quota logic need (today these are throwaway `[verified §2.11]`):
@@ -81,21 +84,24 @@ Persist, on the request, what the cron and quota logic need (today these are thr
 
 ## 4. Schema additions `[SCHEMA]` — DEPENDENCY (Dataverse fields must be created)
 
-On `akoya_request` (or a single JSON config field `wmkf_reviewcampaignconfig` — decide at build):
-`respond_offset_days`, `review_due_date`, `respond_reminder_enabled`, `respond_reminder_lead_days`, `reviewdue_reminder_enabled`, `reviewdue_reminder_lead_days`, `desired_count`, `quota_notified_at`.
+On `akoya_request` — **discrete Dataverse columns** for everything the cron or sweep must `$filter` on (Codex P2: a JSON blob is NOT server-queryable via OData `$filter`):
+`respond_offset_days`, `review_due_date`, `respond_reminder_enabled`, `respond_reminder_lead_days`, `reviewdue_reminder_enabled`, `reviewdue_reminder_lead_days`, `desired_count`, `quota_notified_at`. (A JSON blob is acceptable ONLY for values never used in a server-side filter — but for simplicity, make them all discrete.)
 
 On `wmkf_appreviewersuggestion`:
 `wmkf_respondremindersentat` (datetime).
 
-> These are new fields — a real dependency (Dataverse admin / migration), not just code. The cron filters need them queryable, which favors discrete fields over a JSON blob for the ones the cron filters on (`reminder_enabled`, dates); the rest can be JSON.
+> These are new fields — a real dependency (Dataverse admin / migration), not just code.
 
 ---
 
 ## 5. Sequencing
 
-- **Phase 1 — Persistence + panel + token cap:** campaign config on the request; panel "days to respond" change; `render-emails` picks token expiry from config (invite = review-due + grace, materials = long). Foundation for everything else.
-- **Phase 2 — Reminders:** the two-reminder daily cron + the `wmkf_respondremindersentat` marker.
-- **Phase 3 — Release + Quota:** the accepted-only Release action; quota count/notify in the accept path; the PD selective-decline Workbench action (writes `withdrawn_sufficient`).
+> **Reordered (Codex P1):** the token cap must NOT ship before the Release action, or an accepted reviewer's invite link can die at review-due before any built mechanism exists to send them the long-lived materials link.
+
+- **Phase 1 — Persistence + panel:** campaign config (discrete columns, §4) on the request; panel "days to respond" (offset) change. **No token-behavior change yet** — invite keeps minting `now + 90`. Pure foundation.
+- **Phase 2 — Release + token TTL (ship together):** the accepted-only Release action (mints the long-lived materials token) **and** the invite/reminder token cap (review-due + grace), landed in the same release so the long-lived materials link always exists before the cap can bite. **Also here:** add the missing `materials_sent` server-side guard on the upload endpoint (Codex P2 — `pages/api/external/review/[token]/upload.js` → `lib/services/review-upload.js` accept any valid token today without checking `wmkf_reviewstatus`, so an accepted-pre-materials reviewer could upload).
+- **Phase 3 — Reminders:** the two-reminder daily cron + the `wmkf_respondremindersentat` marker (with Re-invite clearing it, §3.B).
+- **Phase 4 — Quota:** count-after-write + conditional null→set notify + the PD selective-decline Workbench action (writes `withdrawn_sufficient`).
 
 Independent of all of the above: the invitation copy still needs the **Model-B fix** (the shipped copy says "no commitment today, COI/AI + honorarium come later" — wrong; should say "you confirm COI/AI + honorarium details when you accept; the proposal follows later"). Small, do anytime.
 
@@ -106,4 +112,6 @@ Independent of all of the above: the invitation copy still needs the **Model-B f
 - **Honorarium stays capture-only** this cycle `[verified §2.3]`; none of this changes that.
 - **Token cap depends on a sane review-due date** in the config; if absent, fall back to the current `now + 90` (don't silently mint a past-dated/expired token).
 - **Latest-link-wins is now explicit** `[verified §2.6]`: every reminder/materials email supersedes prior links; reviewer-facing copy already corrected (S275) to "use the link in this email."
-- **Quota count runs in the external accept path** (`respond.js`) — a Dataverse count query per accept; acceptable (low volume), guard the notify with the first-writer flag.
+- **Quota count runs in the external accept path** (`respond.js`) — a Dataverse count query per accept, **after** the accept write; acceptable (low volume); the notify is a conditional null→set on `wmkf_quotanotifiedat` (§3.C).
+- **Pre-existing upload soundness gap (Codex P2):** `/upload` accepts any valid token without a `materials_sent` check — an accepted-pre-materials reviewer could upload before release. Closed in Phase 2 (§5).
+- **Expired-but-still-pending window (Codex P2):** between review-due (token dies) and meeting-date (sweep closes), a non-responder reads "pending" in staff UI but can't respond. Surface "link expired" in the staff view, or tighten the sweep (§3.D).

--- a/docs/REVIEWER_INTERACTION_DESIGN.md
+++ b/docs/REVIEWER_INTERACTION_DESIGN.md
@@ -150,7 +150,7 @@ The reviewer clicks the magic link. They see one page with several stacked eleme
 
 **Materials notification:**
 
-When materials become available, the reviewer is notified via a fresh email that points back to the same magic link they already have. The URL does not change across the journey; the backend flips the page from Stage 2a to Stage 2b state. Existing calendar invites continue to point at the same link.
+When materials become available, the reviewer is notified via a fresh email containing a NEW secure link. **The link is NOT stable across the journey** (corrected 2026-06-21 to match the code): the send path (`pages/api/review-manager/render-emails.js`) re-mints the JWT and overwrites the stored hash on every email that contains `{{externalLink}}`, so any earlier link (the original invitation, a prior reminder) **stops verifying** once a newer email goes out — "the email body becomes the canonical link." The backend still resolves the same engagement (the `wmkf_appreviewersuggestion` row) regardless of which token is presented, and flips the page from Stage 2a to Stage 2b state — but reviewers must use the link in the **most recent** email. (Any future calendar-invite feature must therefore embed the link from whichever email is current, not a one-time URL.)
 
 **Stage 2b landing page** (same URL, materials-available state):
 

--- a/docs/REVIEWER_ONBOARDING_FLOW_MOCKUP.md
+++ b/docs/REVIEWER_ONBOARDING_FLOW_MOCKUP.md
@@ -209,9 +209,10 @@ A short confirmation that the decline was recorded, with the option to switch ba
 
 ### Screen 4 — Materials available (later stage, `stage2b`)
 
-When staff release the proposal materials, the reviewer is emailed again; the same link now opens
-the **Materials** view to read the proposal and submit their review. (Out of scope for onboarding,
-shown here for continuity.)
+When staff release the proposal materials, the reviewer is emailed again; the link in that NEW
+email opens the **Materials** view (the send path re-mints the token, so it differs from the
+invitation link — see `REVIEWER_INTERACTION_DESIGN.md` Stage 4; reviewers use the most recent
+email). (Out of scope for onboarding, shown here for continuity.)
 
 ---
 

--- a/docs/REVIEWER_STAGE_2A_BUILD_PLAN.md
+++ b/docs/REVIEWER_STAGE_2A_BUILD_PLAN.md
@@ -12,7 +12,7 @@
 
 A vertical slice of the Stage 2a landing page that covers the proposal summary card, contact-info confirmation, honorarium opt-out, **policy acknowledgment for COI and AI use** (Dynamics-native), and accept/decline events. Production-honest from day one — accept requires both policy acks, matching the design doc contract.
 
-The slice **extends the existing `/external/review/[token]` route family** (rather than building a parallel `/external/landing/*`) and writes engagement-scope state to **`wmkf_appreviewersuggestions`** (the entity the existing magic-link primitive already resolves and writes to). This matches the design doc's "URL does not change across the journey" rule and avoids duplicating state already on the suggestion row.
+The slice **extends the existing `/external/review/[token]` route family** (rather than building a parallel `/external/landing/*`) and writes engagement-scope state to **`wmkf_appreviewersuggestions`** (the entity the existing magic-link primitive already resolves and writes to). This matches the design doc's "same ROUTE/page across the journey, state-driven" rule (the `/external/review/[token]` route and the engagement it resolves are stable) and avoids duplicating state already on the suggestion row. NOTE (corrected 2026-06-21): the TOKEN inside that URL is NOT stable — the send path re-mints it on every email, so the full link changes between the invitation, materials, and any reminder; only the route + resolved engagement persist. See `REVIEWER_INTERACTION_DESIGN.md` Stage 4.
 
 Rationale:
 - Contact-confirmation + accept/decline + policy acks are the highest-leverage mechanics — they unlock the data downstream consumers want (decline reasons, referrals, accept timestamps, contact corrections, compliance-grade COI capture).
@@ -304,7 +304,7 @@ All writes to `wmkf_appreviewersuggestions` use `If-Match` with the row's `_etag
 
 ## 6. Page composition
 
-**Same URL across the journey** (per design doc Stage 4: *"the URL does not change across the journey; the backend flips the page from Stage 2a to Stage 2b state"*). We extend the existing `pages/external/review/[token].js` rather than creating a parallel `pages/external/landing/[token].js` — page state, driven by the response from `/context`, picks which view renders.
+**Same ROUTE/page across the journey** — `pages/external/review/[token].js`, with page state driven by `/context` picking which view renders — rather than a parallel `pages/external/landing/[token].js`. NOTE (corrected 2026-06-21): the design doc's older "the URL does not change" wording was wrong about the LINK — the send path re-mints the token per email, so the full URL (its token) changes between invitation/materials/reminders; the stable thing is the route + the engagement it resolves, not the link. See `REVIEWER_INTERACTION_DESIGN.md` Stage 4.
 
 ### View dispatch (driven by `/context` response)
 

--- a/shared/components/reviewers/email-template-store.js
+++ b/shared/components/reviewers/email-template-store.js
@@ -76,7 +76,7 @@ Thank you for holding your spot. The proposal "{{proposalTitle}}" from {{piInsti
 Please use your secure personal link to confirm the final details — the conflict-of-interest and AI-use acknowledgements, and how you'd like any honorarium handled — and to access the proposal materials:
 {{externalLink}}
 
-We ask that you complete this step by {{reviewDueDate}}. The same link will give you the materials and the review form once you've confirmed.
+We ask that you complete this step by {{reviewDueDate}}. Once you've confirmed, the secure link in this email gives you the materials and the review form.
 
 We're grateful for your time and expertise.
 
@@ -105,7 +105,7 @@ Thank you for your time and expertise.
 
 This is a friendly reminder that your review of "{{proposalTitle}}" is due by {{reviewDueDate}}.
 
-Your secure reviewer link (also in the original invitation):
+Your secure reviewer link (use the one in this email — it supersedes any earlier link):
 {{externalLink}}
 
 Please let us know if you need additional time or have any questions.


### PR DESCRIPTION
## Summary

Lands the S274/S275 reviewer-engagement design bundle. Docs + memory + one small email-copy correction — **no behavior change**.

- **Reviewer-engagement spec** (`docs/REVIEWER_ENGAGEMENT_SPEC.md`) — Model B (accept-now) spine verified against live code, plus Release-to-reviewers, two reminders, PD-confirmed quota + selective decline, and state-split token TTL. 4-phase sequencing + new Dataverse field dependency. Codex-vetted.
- **Codex Model-B interpretation** (`docs/REVIEWER_ENGAGEMENT_PLAN_INTERPRETATION.md`) — flow interpretation (mermaid) + open questions.
- **Link-permanence correction** — `render-emails` re-mints the secure link per email ("latest link wins"); corrected 3 design docs + the email-template-store copy.
- **New always-read memory** `feedback-behavior-claims-cite-the-producer` — tag behavior claims `[verified file:line]`/`[unverified]`; cite the producer not the consumer.
- SESSION_PROMPT updated to S275.

## Risk

Low. Documentation, memory, and a copy string only; no code path or schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)