### PR TITLE
fix(reviewer): Model-B invitation copy (confirm COI/AI + honorarium at accept)

### DIFF
--- a/docs/REVIEWER_ENGAGEMENT_SPEC.md
+++ b/docs/REVIEWER_ENGAGEMENT_SPEC.md
@@ -111,7 +111,7 @@ On `wmkf_appreviewersuggestion`:
 - **Phase 3 — Reminders:** the two-reminder daily cron + the `wmkf_respondremindersentat` marker (with Re-invite clearing it, §3.B).
 - **Phase 4 — Quota:** count-after-write + conditional null→set notify + the PD selective-decline Workbench action (writes `withdrawn_sufficient`).
 
-Independent of all of the above: the invitation copy still needs the **Model-B fix** (the shipped copy says "no commitment today, COI/AI + honorarium come later" — wrong; should say "you confirm COI/AI + honorarium details when you accept; the proposal follows later"). Small, do anytime.
+**Model-B invitation copy — DONE (S275).** The default invitation template (`shared/components/reviewers/email-template-store.js` `DEFAULT_TEMPLATES.invitation`) now says the COI/AI acknowledgements + honorarium are confirmed *when you accept*, with the full proposal following on release — no longer the Model-A "no commitment today, all comes later." (The dormant `hold` template keeps its own copy by design; it's the agree-in-principle flow and is not used in Model B. A PD who saved a customized invitation template keeps their own wording — only the default changed.)
 
 ---
 

--- a/shared/components/reviewers/email-template-store.js
+++ b/shared/components/reviewers/email-template-store.js
@@ -34,13 +34,13 @@ export const DEFAULT_TEMPLATES = {
     subject: 'Invitation to review for the W. M. Keck Foundation — {{proposalTitle}}',
     body: `{{greeting}},
 
-The W. M. Keck Foundation is assembling a review panel and would value your expertise. We're writing to ask whether you'd be willing to review the proposal below — the full materials will follow shortly. For now we simply need to know whether you can take it on, or whether we should look elsewhere.
+The W. M. Keck Foundation is assembling a review panel and would value your expertise. We're writing to ask whether you'd be willing to review the proposal below. The summary here is enough to decide — and to flag any conflict of interest — before the full materials go out.
 
 {{proposalDetails}}
 
 {{proposalAbstract}}
 
-Please use your secure personal link to let us know you can review it — or to pass:
+Please use your secure personal link to accept or decline:
 {{externalLink}}
 
 Review timeline:
@@ -48,7 +48,7 @@ Review timeline:
 - We expect to send the full proposal and review form on {{proposalDelivery}}.
 - Completed reviews would be due by {{reviewDue}}.
 
-The details above should let you flag any conflict of interest now, before the materials go out. There's no further commitment today — the conflict-of-interest and AI-use acknowledgements and any honorarium details all come later, once the proposal is released. We would be grateful for your help.
+When you accept, you'll confirm a few details — the conflict-of-interest and AI-use acknowledgements, and how you'd like any honorarium handled. The full proposal and review form then follow once it's released for review. If the summary already surfaces a conflict, a quick decline is just as helpful. We would be grateful for your help.
 
 {{signature}}`,
   },


### PR DESCRIPTION
Updates the default invitation template to Model B: the COI/AI acknowledgements and honorarium are confirmed **when the reviewer accepts**, with the full proposal following on release — replacing the Model-A "no commitment today, all comes later" wording. Copy-only; the dormant `hold` template is unchanged; a PD with a saved custom template keeps their wording.

Closes the last item of the reviewer-engagement build (spec §5 trailer). Lint clean; invite/template tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)